### PR TITLE
Add library license attributions

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,282 @@
+# Third-Party Licenses
+
+このプロジェクトは以下のオープンソースライブラリを使用しています。
+
+## Dependencies (本番依存関係)
+
+### React
+- **パッケージ名**: react
+- **バージョン**: ^18.3.1
+- **ライセンス**: MIT
+- **著作権者**: Meta Platforms, Inc. and affiliates
+- **リポジトリ**: https://github.com/facebook/react
+
+### React DOM
+- **パッケージ名**: react-dom
+- **バージョン**: ^18.3.1
+- **ライセンス**: MIT
+- **著作権者**: Meta Platforms, Inc. and affiliates
+- **リポジトリ**: https://github.com/facebook/react
+
+### TanStack React Router
+- **パッケージ名**: @tanstack/react-router
+- **バージョン**: ^1.120.3
+- **ライセンス**: MIT
+- **著作権者**: Tanner Linsley
+- **リポジトリ**: https://github.com/TanStack/router
+
+### TanStack React Start
+- **パッケージ名**: @tanstack/react-start
+- **バージョン**: ^1.120.3
+- **ライセンス**: MIT
+- **著作権者**: Tanner Linsley
+- **リポジトリ**: https://github.com/TanStack/start
+
+## DevDependencies (開発依存関係)
+
+### Cloudflare Vite Plugin
+- **パッケージ名**: @cloudflare/vite-plugin
+- **バージョン**: ^1.0.0
+- **ライセンス**: MIT
+- **著作権者**: Cloudflare, Inc.
+- **リポジトリ**: https://github.com/cloudflare/workers-sdk
+
+### Cloudflare Workers Types
+- **パッケージ名**: @cloudflare/workers-types
+- **バージョン**: ^4.20251225.0
+- **ライセンス**: MIT OR Apache-2.0
+- **著作権者**: Cloudflare, Inc.
+- **リポジトリ**: https://github.com/cloudflare/workers-types
+
+### Playwright Test
+- **パッケージ名**: @playwright/test
+- **バージョン**: ^1.57.0
+- **ライセンス**: Apache-2.0
+- **著作権者**: Microsoft Corporation
+- **リポジトリ**: https://github.com/microsoft/playwright
+
+### TanStack Router Plugin
+- **パッケージ名**: @tanstack/router-plugin
+- **バージョン**: ^1.120.3
+- **ライセンス**: MIT
+- **著作権者**: Tanner Linsley
+- **リポジトリ**: https://github.com/TanStack/router
+
+### TypeScript Type Definitions for Node.js
+- **パッケージ名**: @types/node
+- **バージョン**: ^25.0.3
+- **ライセンス**: MIT
+- **著作権者**: DefinitelyTyped contributors
+- **リポジトリ**: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+### TypeScript Type Definitions for React
+- **パッケージ名**: @types/react
+- **バージョン**: ^18.3.1
+- **ライセンス**: MIT
+- **著作権者**: DefinitelyTyped contributors
+- **リポジトリ**: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+### TypeScript Type Definitions for React DOM
+- **パッケージ名**: @types/react-dom
+- **バージョン**: ^18.3.1
+- **ライセンス**: MIT
+- **著作権者**: DefinitelyTyped contributors
+- **リポジトリ**: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+### Vitest Coverage V8
+- **パッケージ名**: @vitest/coverage-v8
+- **バージョン**: ^4.0.16
+- **ライセンス**: MIT
+- **著作権者**: Vitest contributors
+- **リポジトリ**: https://github.com/vitest-dev/vitest
+
+### Serve
+- **パッケージ名**: serve
+- **バージョン**: ^14.2.5
+- **ライセンス**: MIT
+- **著作権者**: Vercel, Inc.
+- **リポジトリ**: https://github.com/vercel/serve
+
+### tsx
+- **パッケージ名**: tsx
+- **バージョン**: ^4.21.0
+- **ライセンス**: MIT
+- **著作権者**: Hiroki Osame
+- **リポジトリ**: https://github.com/privatenumber/tsx
+
+### TypeScript
+- **パッケージ名**: typescript
+- **バージョン**: ^5.9.3
+- **ライセンス**: Apache-2.0
+- **著作権者**: Microsoft Corporation
+- **リポジトリ**: https://github.com/microsoft/TypeScript
+
+### Vite
+- **パッケージ名**: vite
+- **バージョン**: ^7.0.0
+- **ライセンス**: MIT
+- **著作権者**: Evan You and Vite contributors
+- **リポジトリ**: https://github.com/vitejs/vite
+
+### vite-tsconfig-paths
+- **パッケージ名**: vite-tsconfig-paths
+- **バージョン**: ^5.1.4
+- **ライセンス**: MIT
+- **著作権者**: Alec Larson
+- **リポジトリ**: https://github.com/aleclarson/vite-tsconfig-paths
+
+### Vitest
+- **パッケージ名**: vitest
+- **バージョン**: ^4.0.16
+- **ライセンス**: MIT
+- **著作権者**: Vitest contributors
+- **リポジトリ**: https://github.com/vitest-dev/vitest
+
+### wait-on
+- **パッケージ名**: wait-on
+- **バージョン**: ^9.0.3
+- **ライセンス**: MIT
+- **著作権者**: Jeff Barczewski
+- **リポジトリ**: https://github.com/jeffbski/wait-on
+
+### Wrangler
+- **パッケージ名**: wrangler
+- **バージョン**: 4.54.0
+- **ライセンス**: MIT OR Apache-2.0
+- **著作権者**: Cloudflare, Inc.
+- **リポジトリ**: https://github.com/cloudflare/workers-sdk
+
+---
+
+## License Texts
+
+### MIT License
+
+```
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Apache License 2.0
+
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work.
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright
+   owner or by an individual or Legal Entity authorized to submit on
+   behalf of the copyright owner.
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file.
+
+5. Submission of Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor.
+
+7. Disclaimer of Warranty.
+
+8. Limitation of Liability.
+
+9. Accepting Warranty or Additional Liability.
+
+END OF TERMS AND CONDITIONS
+```
+
+---
+
+*This file was last updated: 2025-12-28*


### PR DESCRIPTION
プロジェクトで使用している全ての依存ライブラリのライセンス情報を
THIRD-PARTY-LICENSES.mdファイルに記載しました。

含まれる情報:
- 本番依存関係: React, React DOM, TanStack Router/Start
- 開発依存関係: Vite, TypeScript, Playwright, Vitest等
- 各ライブラリのバージョン、ライセンス種別、著作権者、リポジトリURL
- MITライセンスおよびApache-2.0ライセンスの全文

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Third-Party Licenses documentation file detailing all included open-source dependencies, their versions, licenses, and copyright information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->