### PR TITLE
ダミー画像生成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Cloudflare Workers上で動作するWebツール集です。以下のツール�
 - **正規表現チェッカー** - 正規表現のテスト・検証
 - **JWTデコーダー** - JWTトークンのデコード・検証
 - **OGPチェッカー** - Open Graph Protocol情報の取得・確認
+- **ダミー画像生成** - 開発用プレースホルダー画像の生成
 
 ## 技術スタック
 
@@ -146,7 +147,8 @@ npm run build && npm run test:e2e
 │   │   ├── server-env.tsx       # サーバー環境ページ (/server-env)
 │   │   ├── regex-checker.tsx    # 正規表現チェッカーページ (/regex-checker)
 │   │   ├── jwt.tsx              # JWTデコーダーページ (/jwt)
-│   │   └── ogp.tsx              # OGPチェッカーページ (/ogp)
+│   │   ├── ogp.tsx              # OGPチェッカーページ (/ogp)
+│   │   └── dummy-image.tsx      # ダミー画像生成ページ (/dummy-image)
 │   └── functions/
 │       ├── whois.ts             # WHOISサーバーファンクション
 │       ├── ip-geolocation.ts    # IPジオロケーションファンクション
@@ -163,7 +165,8 @@ npm run build && npm run test:e2e
 │   │   ├── json.test.ts
 │   │   ├── regex.test.ts
 │   │   ├── ip-validation.test.ts
-│   │   └── ogp.test.ts
+│   │   ├── ogp.test.ts
+│   │   └── dummy-image.test.ts
 │   └── e2e/              # E2Eテスト（Playwright）
 │       ├── navigation.spec.ts
 │       ├── unicode.spec.ts
@@ -178,6 +181,7 @@ npm run build && npm run test:e2e
 │       ├── regex-checker.spec.ts
 │       ├── jwt.spec.ts
 │       ├── ogp.spec.ts
+│       ├── dummy-image.spec.ts
 │       ├── accessibility.spec.ts
 │       └── not-found.spec.ts
 ├── package.json

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as JsonRouteImport } from './routes/json'
 import { Route as IpGeolocationRouteImport } from './routes/ip-geolocation'
 import { Route as GlobalIpRouteImport } from './routes/global-ip'
 import { Route as EmailDnsRouteImport } from './routes/email-dns'
+import { Route as DummyImageRouteImport } from './routes/dummy-image'
 import { Route as DummyAudioRouteImport } from './routes/dummy-audio'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -84,6 +85,11 @@ const EmailDnsRoute = EmailDnsRouteImport.update({
   path: '/email-dns',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DummyImageRoute = DummyImageRouteImport.update({
+  id: '/dummy-image',
+  path: '/dummy-image',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DummyAudioRoute = DummyAudioRouteImport.update({
   id: '/dummy-audio',
   path: '/dummy-audio',
@@ -98,6 +104,7 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dummy-audio': typeof DummyAudioRoute
+  '/dummy-image': typeof DummyImageRoute
   '/email-dns': typeof EmailDnsRoute
   '/global-ip': typeof GlobalIpRoute
   '/ip-geolocation': typeof IpGeolocationRoute
@@ -114,6 +121,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dummy-audio': typeof DummyAudioRoute
+  '/dummy-image': typeof DummyImageRoute
   '/email-dns': typeof EmailDnsRoute
   '/global-ip': typeof GlobalIpRoute
   '/ip-geolocation': typeof IpGeolocationRoute
@@ -131,6 +139,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/dummy-audio': typeof DummyAudioRoute
+  '/dummy-image': typeof DummyImageRoute
   '/email-dns': typeof EmailDnsRoute
   '/global-ip': typeof GlobalIpRoute
   '/ip-geolocation': typeof IpGeolocationRoute
@@ -149,6 +158,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/dummy-audio'
+    | '/dummy-image'
     | '/email-dns'
     | '/global-ip'
     | '/ip-geolocation'
@@ -165,6 +175,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/dummy-audio'
+    | '/dummy-image'
     | '/email-dns'
     | '/global-ip'
     | '/ip-geolocation'
@@ -181,6 +192,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/dummy-audio'
+    | '/dummy-image'
     | '/email-dns'
     | '/global-ip'
     | '/ip-geolocation'
@@ -198,6 +210,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DummyAudioRoute: typeof DummyAudioRoute
+  DummyImageRoute: typeof DummyImageRoute
   EmailDnsRoute: typeof EmailDnsRoute
   GlobalIpRoute: typeof GlobalIpRoute
   IpGeolocationRoute: typeof IpGeolocationRoute
@@ -298,6 +311,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EmailDnsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/dummy-image': {
+      id: '/dummy-image'
+      path: '/dummy-image'
+      fullPath: '/dummy-image'
+      preLoaderRoute: typeof DummyImageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dummy-audio': {
       id: '/dummy-audio'
       path: '/dummy-audio'
@@ -318,6 +338,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DummyAudioRoute: DummyAudioRoute,
+  DummyImageRoute: DummyImageRoute,
   EmailDnsRoute: EmailDnsRoute,
   GlobalIpRoute: GlobalIpRoute,
   IpGeolocationRoute: IpGeolocationRoute,

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -158,6 +158,12 @@ function RootDocument({ children }: { children: ReactNode }) {
               >
                 ダミー音声
               </Link>
+              <Link
+                to="/dummy-image"
+                data-active={pathname === "/dummy-image" ? "true" : undefined}
+              >
+                ダミー画像
+              </Link>
             </nav>
           </header>
 

--- a/app/routes/dummy-image.tsx
+++ b/app/routes/dummy-image.tsx
@@ -1,0 +1,612 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export const Route = createFileRoute("/dummy-image")({
+  head: () => ({
+    meta: [{ title: "ダミー画像生成ツール" }],
+  }),
+  component: DummyImageGenerator,
+});
+
+type ImageFormat = "png" | "jpeg" | "webp";
+
+const FORMAT_OPTIONS: { value: ImageFormat; label: string; mimeType: string }[] = [
+  { value: "png", label: "PNG", mimeType: "image/png" },
+  { value: "jpeg", label: "JPEG", mimeType: "image/jpeg" },
+  { value: "webp", label: "WebP", mimeType: "image/webp" },
+];
+
+const PRESET_SIZES = [
+  { label: "SNSアイコン", width: 400, height: 400 },
+  { label: "OGP画像", width: 1200, height: 630 },
+  { label: "HD (720p)", width: 1280, height: 720 },
+  { label: "Full HD (1080p)", width: 1920, height: 1080 },
+  { label: "スマホ縦", width: 375, height: 812 },
+  { label: "タブレット", width: 768, height: 1024 },
+];
+
+const MIN_SIZE = 1;
+const MAX_SIZE = 4096;
+
+/**
+ * Canvas上にダミー画像を描画する
+ * @param canvas - 描画対象のCanvasElement
+ * @param width - 画像の幅
+ * @param height - 画像の高さ
+ * @param bgColor - 背景色
+ * @param textColor - テキスト色
+ */
+export function drawDummyImage(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  bgColor: string,
+  textColor: string
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  canvas.width = width;
+  canvas.height = height;
+
+  // 背景を塗りつぶし
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, width, height);
+
+  // サイズテキストを描画
+  const text = `${width} × ${height}`;
+  const fontSize = Math.min(width, height) / 8;
+  ctx.font = `bold ${fontSize}px 'Roboto', sans-serif`;
+  ctx.fillStyle = textColor;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(text, width / 2, height / 2);
+}
+
+/**
+ * Canvasの内容をBlobに変換する
+ * @param canvas - 変換対象のCanvasElement
+ * @param format - 画像形式
+ * @param quality - 画質（0-1）
+ * @returns Blobを含むPromise
+ */
+export function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  format: ImageFormat,
+  quality: number = 0.92
+): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const mimeType = FORMAT_OPTIONS.find((f) => f.value === format)?.mimeType || "image/png";
+    canvas.toBlob((blob) => resolve(blob), mimeType, quality);
+  });
+}
+
+/**
+ * ダウンロード用のファイル名を生成する
+ * @param width - 画像の幅
+ * @param height - 画像の高さ
+ * @param format - 画像形式
+ * @returns ファイル名
+ */
+export function generateFilename(width: number, height: number, format: ImageFormat): string {
+  return `dummy_${width}x${height}.${format}`;
+}
+
+function DummyImageGenerator() {
+  const [width, setWidth] = useState(800);
+  const [height, setHeight] = useState(600);
+  const [bgColor, setBgColor] = useState("#6750A4");
+  const [textColor, setTextColor] = useState("#FFFFFF");
+  const [format, setFormat] = useState<ImageFormat>("png");
+  const [quality, setQuality] = useState(92);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const announceStatus = useCallback((message: string) => {
+    if (statusRef.current) {
+      statusRef.current.textContent = message;
+      if (statusTimeoutRef.current) {
+        clearTimeout(statusTimeoutRef.current);
+      }
+      statusTimeoutRef.current = setTimeout(() => {
+        if (statusRef.current) {
+          statusRef.current.textContent = "";
+        }
+      }, 3000);
+    }
+  }, []);
+
+  // 画像を描画
+  const renderImage = useCallback(() => {
+    if (canvasRef.current) {
+      drawDummyImage(canvasRef.current, width, height, bgColor, textColor);
+    }
+  }, [width, height, bgColor, textColor]);
+
+  // パラメータ変更時に再描画
+  useEffect(() => {
+    renderImage();
+  }, [renderImage]);
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      if (statusTimeoutRef.current) {
+        clearTimeout(statusTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleWidthChange = useCallback((value: number) => {
+    setWidth(Math.max(MIN_SIZE, Math.min(MAX_SIZE, value || MIN_SIZE)));
+  }, []);
+
+  const handleHeightChange = useCallback((value: number) => {
+    setHeight(Math.max(MIN_SIZE, Math.min(MAX_SIZE, value || MIN_SIZE)));
+  }, []);
+
+  const handlePresetSelect = useCallback((preset: { width: number; height: number }) => {
+    setWidth(preset.width);
+    setHeight(preset.height);
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    if (!canvasRef.current) return;
+
+    const blob = await canvasToBlob(canvasRef.current, format, quality / 100);
+    if (!blob) {
+      announceStatus("画像の生成に失敗しました");
+      return;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const filename = generateFilename(width, height, format);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    announceStatus(`${format.toUpperCase()}ファイルをダウンロードしました`);
+  }, [format, quality, width, height, announceStatus]);
+
+  const handleCopyToClipboard = useCallback(async () => {
+    if (!canvasRef.current) return;
+
+    try {
+      const blob = await canvasToBlob(canvasRef.current, "png");
+      if (!blob) {
+        announceStatus("画像の生成に失敗しました");
+        return;
+      }
+
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blob }),
+      ]);
+      announceStatus("クリップボードにコピーしました");
+    } catch (error) {
+      console.error("Clipboard write failed:", error);
+      announceStatus("クリップボードへのコピーに失敗しました");
+    }
+  }, [announceStatus]);
+
+  return (
+    <>
+      <div className="tool-container">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleDownload();
+          }}
+          aria-label="ダミー画像生成フォーム"
+        >
+          <div className="converter-section">
+            <h2 className="section-title">画像設定</h2>
+
+            <div className="image-options">
+              <div className="option-group">
+                <label htmlFor="width">幅 (px):</label>
+                <input
+                  type="number"
+                  id="width"
+                  min={MIN_SIZE}
+                  max={MAX_SIZE}
+                  value={width}
+                  onChange={(e) => handleWidthChange(parseInt(e.target.value))}
+                  aria-describedby="width-help"
+                />
+                <span id="width-help" className="sr-only">
+                  {MIN_SIZE}から{MAX_SIZE}ピクセルの間で幅を指定できます
+                </span>
+              </div>
+
+              <div className="option-group">
+                <label htmlFor="height">高さ (px):</label>
+                <input
+                  type="number"
+                  id="height"
+                  min={MIN_SIZE}
+                  max={MAX_SIZE}
+                  value={height}
+                  onChange={(e) => handleHeightChange(parseInt(e.target.value))}
+                  aria-describedby="height-help"
+                />
+                <span id="height-help" className="sr-only">
+                  {MIN_SIZE}から{MAX_SIZE}ピクセルの間で高さを指定できます
+                </span>
+              </div>
+
+              <div className="option-group">
+                <label htmlFor="bgColor">背景色:</label>
+                <div className="color-input-wrapper">
+                  <input
+                    type="color"
+                    id="bgColor"
+                    value={bgColor}
+                    onChange={(e) => setBgColor(e.target.value)}
+                    aria-describedby="bgColor-help"
+                  />
+                  <input
+                    type="text"
+                    value={bgColor}
+                    onChange={(e) => setBgColor(e.target.value)}
+                    pattern="^#[0-9A-Fa-f]{6}$"
+                    aria-label="背景色のHEX値"
+                  />
+                </div>
+                <span id="bgColor-help" className="sr-only">
+                  画像の背景色を選択します
+                </span>
+              </div>
+
+              <div className="option-group">
+                <label htmlFor="textColor">テキスト色:</label>
+                <div className="color-input-wrapper">
+                  <input
+                    type="color"
+                    id="textColor"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    aria-describedby="textColor-help"
+                  />
+                  <input
+                    type="text"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    pattern="^#[0-9A-Fa-f]{6}$"
+                    aria-label="テキスト色のHEX値"
+                  />
+                </div>
+                <span id="textColor-help" className="sr-only">
+                  サイズ表示テキストの色を選択します
+                </span>
+              </div>
+
+              <div className="option-group">
+                <label htmlFor="format">形式:</label>
+                <select
+                  id="format"
+                  value={format}
+                  onChange={(e) => setFormat(e.target.value as ImageFormat)}
+                  aria-describedby="format-help"
+                >
+                  {FORMAT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <span id="format-help" className="sr-only">
+                  ダウンロードする画像の形式を選択します
+                </span>
+              </div>
+
+              {format !== "png" && (
+                <div className="option-group quality-group">
+                  <label htmlFor="quality">画質: {quality}%</label>
+                  <input
+                    type="range"
+                    id="quality"
+                    min="1"
+                    max="100"
+                    value={quality}
+                    onChange={(e) => setQuality(parseInt(e.target.value))}
+                    aria-describedby="quality-help"
+                  />
+                  <span id="quality-help" className="sr-only">
+                    1%から100%の間で画質を指定できます
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="preset-section">
+              <h3 className="preset-title">プリセットサイズ</h3>
+              <div className="preset-buttons" role="group" aria-label="プリセットサイズ選択">
+                {PRESET_SIZES.map((preset) => (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    className="btn-preset"
+                    onClick={() => handlePresetSelect(preset)}
+                    aria-label={`${preset.label} (${preset.width}x${preset.height})`}
+                  >
+                    {preset.label}
+                    <span className="preset-size">
+                      {preset.width}×{preset.height}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="button-group" role="group" aria-label="画像操作">
+              <button type="submit" className="btn-primary">
+                ダウンロード
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={handleCopyToClipboard}
+              >
+                クリップボードにコピー
+              </button>
+            </div>
+          </div>
+
+          <div className="converter-section">
+            <h2 className="section-title">プレビュー</h2>
+            <div className="preview-container">
+              <canvas
+                ref={canvasRef}
+                aria-label={`プレビュー画像 (${width}x${height})`}
+              />
+            </div>
+            <div className="image-info">
+              <div className="info-item">
+                <span className="info-label">サイズ:</span>
+                <span className="info-value">{width} × {height} px</span>
+              </div>
+              <div className="info-item">
+                <span className="info-label">形式:</span>
+                <span className="info-value">{FORMAT_OPTIONS.find((f) => f.value === format)?.label}</span>
+              </div>
+              {format !== "png" && (
+                <div className="info-item">
+                  <span className="info-label">画質:</span>
+                  <span className="info-value">{quality}%</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <aside
+          className="info-box"
+          role="complementary"
+          aria-labelledby="usage-title"
+        >
+          <h3 id="usage-title">ダミー画像生成とは</h3>
+          <ul>
+            <li>開発やデザインモックアップ用のプレースホルダー画像を生成します</li>
+            <li>指定したサイズと色で画像を作成</li>
+            <li>PNG、JPEG、WebP形式でダウンロード可能</li>
+          </ul>
+          <h3 id="format-title">形式について</h3>
+          <ul>
+            <li><strong>PNG:</strong> 可逆圧縮、透明度対応、ロゴやアイコンに最適</li>
+            <li><strong>JPEG:</strong> 非可逆圧縮、写真に最適、ファイルサイズ小</li>
+            <li><strong>WebP:</strong> 高圧縮率、モダンブラウザ対応</li>
+          </ul>
+          <h3 id="about-tool-title">使い方</h3>
+          <ul>
+            <li>幅と高さを指定、またはプリセットを選択</li>
+            <li>背景色とテキスト色を設定</li>
+            <li>プレビューで確認</li>
+            <li>「ダウンロード」で画像を保存</li>
+          </ul>
+        </aside>
+      </div>
+
+      <div
+        ref={statusRef}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      />
+
+      <style>{`
+        .image-options {
+          display: flex;
+          gap: 1.5rem;
+          flex-wrap: wrap;
+          align-items: flex-start;
+          margin-bottom: 1.5rem;
+        }
+
+        .option-group {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+
+        .option-group label {
+          font-weight: 500;
+          color: var(--md-sys-color-on-surface);
+        }
+
+        .option-group select,
+        .option-group input[type="number"] {
+          padding: 0.5rem;
+          border: 1px solid var(--md-sys-color-outline);
+          border-radius: 8px;
+          font-size: 1rem;
+          background-color: var(--md-sys-color-surface);
+          color: var(--md-sys-color-on-surface);
+          min-width: 120px;
+        }
+
+        .color-input-wrapper {
+          display: flex;
+          gap: 0.5rem;
+          align-items: center;
+        }
+
+        .color-input-wrapper input[type="color"] {
+          width: 40px;
+          height: 40px;
+          padding: 0;
+          border: 1px solid var(--md-sys-color-outline);
+          border-radius: 8px;
+          cursor: pointer;
+        }
+
+        .color-input-wrapper input[type="text"] {
+          width: 90px;
+          padding: 0.5rem;
+          border: 1px solid var(--md-sys-color-outline);
+          border-radius: 8px;
+          font-size: 0.875rem;
+          font-family: 'Roboto Mono', monospace;
+          background-color: var(--md-sys-color-surface);
+          color: var(--md-sys-color-on-surface);
+        }
+
+        .quality-group {
+          min-width: 200px;
+        }
+
+        .option-group input[type="range"] {
+          width: 100%;
+          accent-color: var(--md-sys-color-primary);
+        }
+
+        .preset-section {
+          margin-bottom: 1.5rem;
+        }
+
+        .preset-title {
+          font-size: 1rem;
+          font-weight: 500;
+          color: var(--md-sys-color-on-surface);
+          margin-bottom: 0.75rem;
+        }
+
+        .preset-buttons {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5rem;
+        }
+
+        .btn-preset {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 0.5rem 1rem;
+          border: 1px solid var(--md-sys-color-outline);
+          border-radius: 8px;
+          background-color: var(--md-sys-color-surface);
+          color: var(--md-sys-color-on-surface);
+          cursor: pointer;
+          transition: background-color 0.2s, border-color 0.2s;
+        }
+
+        .btn-preset:hover {
+          background-color: var(--md-sys-color-surface-variant);
+          border-color: var(--md-sys-color-primary);
+        }
+
+        .preset-size {
+          font-size: 0.75rem;
+          color: var(--md-sys-color-on-surface-variant);
+          font-family: 'Roboto Mono', monospace;
+        }
+
+        .preview-container {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          padding: 1rem;
+          background-color: var(--md-sys-color-surface-variant);
+          border-radius: 12px;
+          overflow: auto;
+          max-height: 400px;
+          margin-bottom: 1rem;
+        }
+
+        .preview-container canvas {
+          max-width: 100%;
+          max-height: 100%;
+          object-fit: contain;
+          border-radius: 4px;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .image-info {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .info-item {
+          display: flex;
+          gap: 0.5rem;
+          padding: 0.5rem 1rem;
+          background-color: var(--md-sys-color-surface-variant);
+          border-radius: 8px;
+        }
+
+        .info-label {
+          font-weight: 500;
+          color: var(--md-sys-color-on-surface-variant);
+        }
+
+        .info-value {
+          font-family: 'Roboto Mono', monospace;
+          color: var(--md-sys-color-on-surface);
+        }
+
+        @media (max-width: 480px) {
+          .image-options {
+            flex-direction: column;
+          }
+
+          .option-group {
+            width: 100%;
+          }
+
+          .option-group select,
+          .option-group input[type="number"] {
+            width: 100%;
+          }
+
+          .color-input-wrapper {
+            width: 100%;
+          }
+
+          .color-input-wrapper input[type="text"] {
+            flex: 1;
+          }
+
+          .preset-buttons {
+            flex-direction: column;
+          }
+
+          .btn-preset {
+            width: 100%;
+          }
+
+          .image-info {
+            flex-direction: column;
+          }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/tests/e2e/dummy-image.spec.ts
+++ b/tests/e2e/dummy-image.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dummy Image Generator - E2E Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dummy-image');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should load the page without "undefined" content', async ({ page }) => {
+    const bodyText = await page.textContent('body');
+    expect(bodyText).not.toContain('undefined');
+    expect(bodyText).not.toBe('undefined');
+  });
+
+  test('should display the correct page title', async ({ page }) => {
+    await expect(page).toHaveTitle(/ダミー画像生成/);
+  });
+
+  test('should display the main heading', async ({ page }) => {
+    const heading = page.locator('.section-title').first();
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('画像設定');
+  });
+
+  test('should have proper accessibility attributes', async ({ page }) => {
+    await expect(page.locator('[role="banner"]')).toBeVisible();
+    await expect(page.locator('[role="main"]')).toBeVisible();
+    const skipLink = page.locator('.skip-link');
+    await expect(skipLink).toBeAttached();
+  });
+
+  test('should display usage instructions', async ({ page }) => {
+    const usageSection = page.locator('.info-box');
+    await expect(usageSection).toBeVisible();
+
+    const usageText = await usageSection.textContent();
+    expect(usageText).toContain('ダミー画像生成とは');
+    expect(usageText).not.toContain('undefined');
+  });
+
+  test('should have navigation links including ダミー画像', async ({ page }) => {
+    const navLinks = page.locator('.nav-links');
+    await expect(navLinks).toBeVisible();
+
+    const dummyImageLink = page.locator('.nav-links a[href="/dummy-image"]');
+    await expect(dummyImageLink).toBeVisible();
+    await expect(dummyImageLink).toContainText('ダミー画像');
+  });
+
+  test('should show active state on ダミー画像 link', async ({ page }) => {
+    const activeLink = page.locator('.nav-links a[data-active="true"]');
+    await expect(activeLink).toContainText('ダミー画像');
+  });
+
+  test('should display width and height inputs', async ({ page }) => {
+    const widthInput = page.locator('input#width');
+    const heightInput = page.locator('input#height');
+
+    await expect(widthInput).toBeVisible();
+    await expect(heightInput).toBeVisible();
+  });
+
+  test('should have default dimensions', async ({ page }) => {
+    const widthInput = page.locator('input#width');
+    const heightInput = page.locator('input#height');
+
+    await expect(widthInput).toHaveValue('800');
+    await expect(heightInput).toHaveValue('600');
+  });
+
+  test('should display color pickers', async ({ page }) => {
+    const bgColorInput = page.locator('input#bgColor');
+    const textColorInput = page.locator('input#textColor');
+
+    await expect(bgColorInput).toBeVisible();
+    await expect(textColorInput).toBeVisible();
+  });
+
+  test('should display format selector', async ({ page }) => {
+    const formatSelect = page.locator('select#format');
+    await expect(formatSelect).toBeVisible();
+
+    const options = page.locator('select#format option');
+    await expect(options).toHaveCount(3);
+  });
+
+  test('should display preset size buttons', async ({ page }) => {
+    const presetButtons = page.locator('.preset-buttons button');
+    await expect(presetButtons.first()).toBeVisible();
+
+    const count = await presetButtons.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('should change dimensions when clicking preset', async ({ page }) => {
+    const ogpPreset = page.locator('button:has-text("OGP画像")');
+    await ogpPreset.click();
+
+    const widthInput = page.locator('input#width');
+    const heightInput = page.locator('input#height');
+
+    await expect(widthInput).toHaveValue('1200');
+    await expect(heightInput).toHaveValue('630');
+  });
+
+  test('should display canvas preview', async ({ page }) => {
+    const canvas = page.locator('canvas');
+    await expect(canvas).toBeVisible();
+  });
+
+  test('should update canvas when dimensions change', async ({ page }) => {
+    const widthInput = page.locator('input#width');
+    await widthInput.fill('400');
+
+    const canvas = page.locator('canvas');
+    await expect(canvas).toHaveAttribute('width', '400');
+  });
+
+  test('should have download button', async ({ page }) => {
+    const downloadButton = page.locator('button.btn-primary');
+    await expect(downloadButton).toBeVisible();
+    await expect(downloadButton).toContainText('ダウンロード');
+  });
+
+  test('should have clipboard copy button', async ({ page }) => {
+    const copyButton = page.locator('button:has-text("クリップボードにコピー")');
+    await expect(copyButton).toBeVisible();
+  });
+
+  test('should display image info', async ({ page }) => {
+    const infoSection = page.locator('.image-info');
+    await expect(infoSection).toBeVisible();
+
+    const infoText = await infoSection.textContent();
+    expect(infoText).toContain('800 × 600');
+    expect(infoText).toContain('PNG');
+  });
+
+  test('should show quality slider when JPEG is selected', async ({ page }) => {
+    const formatSelect = page.locator('select#format');
+    await formatSelect.selectOption('jpeg');
+
+    const qualitySlider = page.locator('input#quality');
+    await expect(qualitySlider).toBeVisible();
+  });
+
+  test('should hide quality slider when PNG is selected', async ({ page }) => {
+    const formatSelect = page.locator('select#format');
+    await formatSelect.selectOption('png');
+
+    const qualitySlider = page.locator('input#quality');
+    await expect(qualitySlider).not.toBeVisible();
+  });
+
+  test('should show quality slider when WebP is selected', async ({ page }) => {
+    const formatSelect = page.locator('select#format');
+    await formatSelect.selectOption('webp');
+
+    const qualitySlider = page.locator('input#quality');
+    await expect(qualitySlider).toBeVisible();
+  });
+
+  test('should navigate to Unicode page when clicking the link', async ({ page }) => {
+    await page.click('.nav-links a[href="/"]');
+    await expect(page).toHaveURL('/');
+  });
+
+  test('should navigate from dummy-audio to dummy-image', async ({ page }) => {
+    await page.goto('/dummy-audio');
+    await page.waitForLoadState('networkidle');
+
+    const dummyImageLink = page.locator('.nav-links a[href="/dummy-image"]');
+    await dummyImageLink.click();
+
+    await expect(page).toHaveURL('/dummy-image');
+  });
+});

--- a/tests/unit/dummy-image.test.ts
+++ b/tests/unit/dummy-image.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { drawDummyImage, generateFilename } from '../../app/routes/dummy-image';
+
+// Mock canvas for testing
+function createMockCanvas(): HTMLCanvasElement {
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({
+      fillStyle: '',
+      font: '',
+      textAlign: '',
+      textBaseline: '',
+      fillRect: () => {},
+      fillText: () => {},
+    }),
+  } as unknown as HTMLCanvasElement;
+  return canvas;
+}
+
+describe('Dummy Image Generation', () => {
+  describe('generateFilename', () => {
+    it('should generate correct filename for PNG', () => {
+      const filename = generateFilename(800, 600, 'png');
+      expect(filename).toBe('dummy_800x600.png');
+    });
+
+    it('should generate correct filename for JPEG', () => {
+      const filename = generateFilename(1920, 1080, 'jpeg');
+      expect(filename).toBe('dummy_1920x1080.jpeg');
+    });
+
+    it('should generate correct filename for WebP', () => {
+      const filename = generateFilename(1200, 630, 'webp');
+      expect(filename).toBe('dummy_1200x630.webp');
+    });
+
+    it('should handle small dimensions', () => {
+      const filename = generateFilename(1, 1, 'png');
+      expect(filename).toBe('dummy_1x1.png');
+    });
+
+    it('should handle large dimensions', () => {
+      const filename = generateFilename(4096, 4096, 'png');
+      expect(filename).toBe('dummy_4096x4096.png');
+    });
+  });
+
+  describe('drawDummyImage', () => {
+    it('should set canvas dimensions correctly', () => {
+      const canvas = createMockCanvas();
+      drawDummyImage(canvas, 800, 600, '#6750A4', '#FFFFFF');
+      expect(canvas.width).toBe(800);
+      expect(canvas.height).toBe(600);
+    });
+
+    it('should handle square dimensions', () => {
+      const canvas = createMockCanvas();
+      drawDummyImage(canvas, 400, 400, '#000000', '#FFFFFF');
+      expect(canvas.width).toBe(400);
+      expect(canvas.height).toBe(400);
+    });
+
+    it('should handle portrait dimensions', () => {
+      const canvas = createMockCanvas();
+      drawDummyImage(canvas, 375, 812, '#FF0000', '#000000');
+      expect(canvas.width).toBe(375);
+      expect(canvas.height).toBe(812);
+    });
+
+    it('should handle landscape dimensions', () => {
+      const canvas = createMockCanvas();
+      drawDummyImage(canvas, 1920, 1080, '#0000FF', '#FFFFFF');
+      expect(canvas.width).toBe(1920);
+      expect(canvas.height).toBe(1080);
+    });
+  });
+
+  describe('Image format options', () => {
+    const formatOptions = [
+      { value: 'png', label: 'PNG', mimeType: 'image/png' },
+      { value: 'jpeg', label: 'JPEG', mimeType: 'image/jpeg' },
+      { value: 'webp', label: 'WebP', mimeType: 'image/webp' },
+    ];
+
+    it('should have all format options defined', () => {
+      expect(formatOptions).toHaveLength(3);
+    });
+
+    it('should have correct MIME types', () => {
+      expect(formatOptions.find(f => f.value === 'png')?.mimeType).toBe('image/png');
+      expect(formatOptions.find(f => f.value === 'jpeg')?.mimeType).toBe('image/jpeg');
+      expect(formatOptions.find(f => f.value === 'webp')?.mimeType).toBe('image/webp');
+    });
+  });
+
+  describe('Preset sizes', () => {
+    const presetSizes = [
+      { label: 'SNSアイコン', width: 400, height: 400 },
+      { label: 'OGP画像', width: 1200, height: 630 },
+      { label: 'HD (720p)', width: 1280, height: 720 },
+      { label: 'Full HD (1080p)', width: 1920, height: 1080 },
+      { label: 'スマホ縦', width: 375, height: 812 },
+      { label: 'タブレット', width: 768, height: 1024 },
+    ];
+
+    it('should have all preset sizes defined', () => {
+      expect(presetSizes).toHaveLength(6);
+    });
+
+    it('should have valid dimensions for all presets', () => {
+      presetSizes.forEach(preset => {
+        expect(preset.width).toBeGreaterThan(0);
+        expect(preset.height).toBeGreaterThan(0);
+        expect(preset.width).toBeLessThanOrEqual(4096);
+        expect(preset.height).toBeLessThanOrEqual(4096);
+      });
+    });
+
+    it('should include SNS icon preset with square dimensions', () => {
+      const snsPreset = presetSizes.find(p => p.label === 'SNSアイコン');
+      expect(snsPreset).toBeDefined();
+      expect(snsPreset?.width).toBe(snsPreset?.height);
+    });
+
+    it('should include OGP preset with standard dimensions', () => {
+      const ogpPreset = presetSizes.find(p => p.label === 'OGP画像');
+      expect(ogpPreset).toBeDefined();
+      expect(ogpPreset?.width).toBe(1200);
+      expect(ogpPreset?.height).toBe(630);
+    });
+  });
+
+  describe('Color validation', () => {
+    it('should accept valid hex colors', () => {
+      const validColors = ['#000000', '#FFFFFF', '#6750A4', '#ff0000', '#00FF00'];
+      validColors.forEach(color => {
+        expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      });
+    });
+
+    it('should recognize invalid hex colors', () => {
+      const invalidColors = ['000000', '#FFF', '#GGGGGG', 'red', 'rgb(0,0,0)'];
+      invalidColors.forEach(color => {
+        expect(color).not.toMatch(/^#[0-9A-Fa-f]{6}$/);
+      });
+    });
+  });
+
+  describe('Size constraints', () => {
+    const MIN_SIZE = 1;
+    const MAX_SIZE = 4096;
+
+    it('should have minimum size of 1', () => {
+      expect(MIN_SIZE).toBe(1);
+    });
+
+    it('should have maximum size of 4096', () => {
+      expect(MAX_SIZE).toBe(4096);
+    });
+
+    it('should clamp values within bounds', () => {
+      const clamp = (value: number) => Math.max(MIN_SIZE, Math.min(MAX_SIZE, value));
+
+      expect(clamp(0)).toBe(MIN_SIZE);
+      expect(clamp(-100)).toBe(MIN_SIZE);
+      expect(clamp(5000)).toBe(MAX_SIZE);
+      expect(clamp(800)).toBe(800);
+    });
+  });
+
+  describe('Quality settings', () => {
+    it('should accept quality values from 1 to 100', () => {
+      for (let quality = 1; quality <= 100; quality++) {
+        expect(quality).toBeGreaterThanOrEqual(1);
+        expect(quality).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it('should convert quality to 0-1 range for canvas API', () => {
+      const qualityPercent = 92;
+      const qualityDecimal = qualityPercent / 100;
+      expect(qualityDecimal).toBeCloseTo(0.92);
+    });
+  });
+});


### PR DESCRIPTION
- Add new dummy-image route with Canvas-based image generation
- Support PNG, JPEG, WebP formats with quality settings
- Include preset sizes (SNS icon, OGP, HD, Full HD, etc.)
- Add color picker for background and text colors
- Support clipboard copy and file download
- Add unit tests and E2E tests
- Update navigation and documentation

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dummy Image Generator tool for creating custom placeholder images with configurable dimensions, background and text colors, and multiple format options including PNG, JPEG, and WebP.
  * Includes preset sizes for common use cases, quality settings for certain formats, and download or clipboard copy functionality.

* **Tests**
  * Added comprehensive unit and end-to-end test coverage for the new feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->