### PR TITLE
fix: add error handling, CDN caching, and consistent font sizing

### DIFF
--- a/app/routes/dummy-image.tsx
+++ b/app/routes/dummy-image.tsx
@@ -53,9 +53,9 @@ export function drawDummyImage(
   ctx.fillStyle = bgColor;
   ctx.fillRect(0, 0, width, height);
 
-  // サイズテキストを描画
+  // サイズテキストを描画（最小フォントサイズ12pxをSVG生成と統一）
   const text = `${width} × ${height}`;
-  const fontSize = Math.min(width, height) / 8;
+  const fontSize = Math.max(12, Math.min(width, height) / 8);
   ctx.font = `bold ${fontSize}px 'Roboto', sans-serif`;
   ctx.fillStyle = textColor;
   ctx.textAlign = "center";

--- a/app/ssr.tsx
+++ b/app/ssr.tsx
@@ -15,17 +15,47 @@ export default {
 
     // /api/image エンドポイント - ダミー画像を直接返す
     if (url.pathname === "/api/image") {
-      const { width, height, bgColor, textColor } = parseImageParams(
-        url.searchParams
-      );
-      const svg = generateSvgImage(width, height, bgColor, textColor);
+      try {
+        // Cloudflare CDNキャッシュを確認
+        const cache = caches.default;
+        const cacheKey = new Request(url.toString(), {
+          method: "GET",
+        });
 
-      return new Response(svg, {
-        headers: {
-          "Content-Type": "image/svg+xml",
-          "Cache-Control": "public, max-age=31536000, immutable",
-        },
-      });
+        // キャッシュから取得を試みる
+        const cachedResponse = await cache.match(cacheKey);
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+
+        // キャッシュにない場合は生成
+        const { width, height, bgColor, textColor } = parseImageParams(
+          url.searchParams
+        );
+        const svg = generateSvgImage(width, height, bgColor, textColor);
+
+        const response = new Response(svg, {
+          headers: {
+            "Content-Type": "image/svg+xml",
+            "Cache-Control": "public, max-age=31536000, immutable",
+          },
+        });
+
+        // レスポンスをCloudflare CDNにキャッシュ
+        ctx.waitUntil(cache.put(cacheKey, response.clone()));
+
+        return response;
+      } catch (error) {
+        // エラー時はデフォルトのエラー画像を返す
+        const errorSvg = generateSvgImage(300, 150, "FF0000", "FFFFFF");
+        return new Response(errorSvg, {
+          status: 500,
+          headers: {
+            "Content-Type": "image/svg+xml",
+            "Cache-Control": "no-store",
+          },
+        });
+      }
     }
 
     const handler = createStartHandler({


### PR DESCRIPTION
- Add try-catch error handling for /api/image endpoint
- Implement Cloudflare CDN caching to reduce Worker invocations
- Unify minimum font size (12px) between SVG and Canvas rendering

Addresses review comments from PR #56