### PR TITLE
fix: プレビューコンテナからスクロールバーを削除

### DIFF
--- a/app/routes/color-extractor.tsx
+++ b/app/routes/color-extractor.tsx
@@ -618,14 +618,11 @@ function ColorExtractor() {
           padding: 1rem;
           background-color: var(--md-sys-color-surface-variant);
           border-radius: 12px;
-          overflow: auto;
-          max-height: 400px;
         }
 
         .preview-container canvas {
           max-width: 100%;
-          max-height: 100%;
-          object-fit: contain;
+          height: auto;
           border-radius: 4px;
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
         }


### PR DESCRIPTION
## 概要
カラー抽出ツールのプレビューコンテナからスクロールバーを削除しました。

## 変更内容
- `overflow: auto` を削除してスクロールバーを非表示に
- `max-height: 400px` を削除してコンテナが自動拡張されるように変更
- canvasに `height: auto` を設定して、コンテナ幅に合わせて自動スケーリング

## 関連PR
- #69 (元のカラー抽出機能PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)