### PR TITLE
fix: 画像→GIF変換で3枚目以降の画像が処理されない問題を修正

### DIFF
--- a/tests/unit/image-to-gif.test.ts
+++ b/tests/unit/image-to-gif.test.ts
@@ -133,10 +133,10 @@ describe("image-to-gif", () => {
       expect(ffmpeg.writeFile).toHaveBeenCalledWith("input1.png", expect.any(Uint8Array));
       expect(ffmpeg.exec).toHaveBeenCalledWith(
         expect.arrayContaining([
-          "-loop", "1", "-framerate", "10", "-t", expect.any(String), "-i", "input0.png",
-          "-loop", "1", "-framerate", "10", "-t", expect.any(String), "-i", "input1.png",
+          "-loop", "1", "-t", expect.any(String), "-i", "input0.png",
+          "-loop", "1", "-t", expect.any(String), "-i", "input1.png",
           "-filter_complex",
-          "concat=n=2:v=1:a=0[v];[v]split[s0][s1];[s0]palettegen=max_colors=256[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5",
+          "concat=n=2:v=1:a=0,fps=10,split[s0][s1];[s0]palettegen=max_colors=256[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5",
           "-loop",
           "0",
           "output.gif",
@@ -151,10 +151,10 @@ describe("image-to-gif", () => {
       expect(result).toBeInstanceOf(Blob);
       expect(ffmpeg.exec).toHaveBeenCalledWith(
         expect.arrayContaining([
-          "-loop", "1", "-framerate", "5", "-t", expect.any(String), "-i", "input0.png",
-          "-loop", "1", "-framerate", "5", "-t", expect.any(String), "-i", "input1.png",
+          "-loop", "1", "-t", expect.any(String), "-i", "input0.png",
+          "-loop", "1", "-t", expect.any(String), "-i", "input1.png",
           "-filter_complex",
-          "concat=n=2:v=1:a=0[v];[v]split[s0][s1];[s0]palettegen=max_colors=256[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5",
+          "concat=n=2:v=1:a=0,fps=5,split[s0][s1];[s0]palettegen=max_colors=256[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5",
           "-loop",
           "3",
           "output.gif",


### PR DESCRIPTION
## 概要
画像→GIF変換機能で、複数画像を選択しても最初の2枚しか反映されない問題を修正しました。

## 問題の原因
FFmpegの`-framerate`オプションを入力パラメータとして使用していたため、`concat`フィルタが正しく動作せず、3枚目以降の画像が処理されませんでした。

## 修正内容
- 入力オプションから`-framerate`を削除
- `filter_complex`内で`fps`フィルタを使用してフレームレートを制御
- 変更前: `-loop 1 -framerate ${framerate} -t ${time} -i input.png`
- 変更後: `-loop 1 -t ${time} -i input.png` + `concat=n=N:v=1:a=0,fps=${framerate},split...`

## テスト
- ユニットテスト: 全て通過 (392 tests)
- ビルド: 成功
- FFmpegコマンド生成機能も修正に合わせて更新

## 関連Issue
複数画像選択時に最初の2枚しか反映されない問題の報告に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)