### PR TITLE
fix: IPv4マップIPv6アドレスの全形式でSSRF保護を強化

### DIFF
--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -105,10 +105,26 @@ describe("SSRF protection - private IP detection", () => {
   });
 
   it("should detect IPv4-mapped IPv6 addresses", () => {
+    // ドット10進表記
     expect(isPrivateOrLocalhost("::ffff:127.0.0.1")).toBe(true);
     expect(isPrivateOrLocalhost("::ffff:10.0.0.1")).toBe(true);
     expect(isPrivateOrLocalhost("::ffff:192.168.1.1")).toBe(true);
     expect(isPrivateOrLocalhost("::ffff:8.8.8.8")).toBe(false);
+
+    // 16進表記
+    expect(isPrivateOrLocalhost("::ffff:c0a8:0101")).toBe(true); // 192.168.1.1 in hex
+    expect(isPrivateOrLocalhost("::ffff:7f00:0001")).toBe(true); // 127.0.0.1 in hex
+    expect(isPrivateOrLocalhost("::ffff:0a00:0001")).toBe(true); // 10.0.0.1 in hex
+    expect(isPrivateOrLocalhost("::ffff:0808:0808")).toBe(false); // 8.8.8.8 in hex
+
+    // 展開形式（16進）
+    expect(isPrivateOrLocalhost("0000:0000:0000:0000:0000:ffff:c0a8:0101")).toBe(true); // 192.168.1.1
+    expect(isPrivateOrLocalhost("0:0:0:0:0:ffff:c0a8:0101")).toBe(true); // 192.168.1.1 (省略形)
+    expect(isPrivateOrLocalhost("0000:0000:0000:0000:0000:ffff:7f00:0001")).toBe(true); // 127.0.0.1
+
+    // 展開形式（ドット10進）
+    expect(isPrivateOrLocalhost("0:0:0:0:0:ffff:192.168.1.1")).toBe(true);
+    expect(isPrivateOrLocalhost("0000:0000:0000:0000:0000:ffff:127.0.0.1")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

PR #120 のCodeRabbitレビューで指摘されたクリティカルな脆弱性に対応し、IPv4マップIPv6アドレスのすべての形式でSSRF保護を強化しました。

## 問題点

現在の実装は、圧縮されたドット10進表記（`::ffff:192.168.1.1`）のみを検出していましたが、以下の形式でバイパスが可能でした：

1. **16進表記**: `::ffff:c0a8:0101` (192.168.1.1を16進で表記)
2. **展開形式（16進）**: `0000:0000:0000:0000:0000:ffff:c0a8:0101`
3. **展開形式（ドット10進）**: `0:0:0:0:0:ffff:192.168.1.1`

攻撃者はこれらの代替表記を使用してプライベートIPアドレスをエンコードし、SSRF保護をバイパスできました。

## 変更内容

### IPv4マップIPv6アドレスの検出強化

1. **ドット10進表記の検出** (既存)
   - `::ffff:192.168.1.1` → プライベートIPとして検出

2. **16進表記の検出** (新規)
   - `::ffff:c0a8:0101` → `192.168.1.1`に変換して検出
   - 16進数から各オクテットを抽出してIPv4アドレスに変換

3. **展開形式（16進）の検出** (新規)
   - `0000:0000:0000:0000:0000:ffff:c0a8:0101` → `192.168.1.1`に変換
   - 正規表現でパターンマッチングして16進部分を抽出

4. **展開形式（ドット10進）の検出** (新規)
   - `0:0:0:0:0:ffff:192.168.1.1` → 直接検出

### テストケース追加

CodeRabbitの提案に基づき、以下のテストケースを追加：

- 16進表記のプライベートIP（127.0.0.1、10.0.0.1、192.168.1.1）
- 16進表記のパブリックIP（8.8.8.8）→ false
- 展開形式（16進）のプライベートIP
- 展開形式（省略形）のプライベートIP
- 展開形式（ドット10進）のプライベートIP

## テスト結果

- ✅ 442テスト全て合格
- ✅ ビルド成功

## セキュリティ影響

この修正により、攻撃者がIPv6の代替表記を使用してSSRF保護をバイパスすることを防ぎます。すべての有効なIPv4マップIPv6アドレス形式が正しく検出されるようになりました。

## 関連PR

- #120 - DNS rebinding対策とIPv4/IPv6検出の強化

🤖 Generated with [Claude Code](https://claude.com/claude-code)