### PR TITLE
fix: OGPチェッカーの文字化けバグ修正と相対パス対応 (#64)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@resvg/resvg-wasm": "^2.6.2",
         "@tanstack/react-router": "^1.120.3",
         "@tanstack/react-start": "^1.120.3",
+        "encoding-japanese": "^2.2.0",
         "lamejs": "^1.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -3414,6 +3415,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@resvg/resvg-wasm": "^2.6.2",
     "@tanstack/react-router": "^1.120.3",
     "@tanstack/react-start": "^1.120.3",
+    "encoding-japanese": "^2.2.0",
     "lamejs": "^1.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
## Summary

- OGPチェッカーで特定サイトの文字エンコーディングが正しく処理されない問題を修正（Issue #64）
- `encoding-japanese`ライブラリを導入し、Shift_JIS、EUC-JP、ISO-2022-JP等の日本語エンコーディングをサポート
- OGP画像URLが相対パスの場合、絶対URLに変換する機能を追加

## Changes

### 文字エンコーディング対応
- `encoding-japanese`ライブラリを追加
- `normalizeCharset`関数を拡張（CP932、Windows-31J、x-sjis等の追加エイリアス対応）
- `detectEncodingFromBytes`関数を追加（バイト列からエンコーディングを自動検出）
- `decodeHtmlWithCharset`関数を改善（日本語エンコーディングは`encoding-japanese`で変換）

### 相対パス対応
- `resolveUrl`関数を追加（相対URL→絶対URL変換）
  - 絶対URL: そのまま返す
  - プロトコル相対URL（`//example.com/...`）: `https:`を追加
  - ルート相対URL（`/path/...`）: ベースURLのオリジンを使用
  - 相対URL（`../path/...`）: ベースURLからの相対パスを解決
- `og:image`と`twitter:image`のURLを自動的に絶対URLに変換

## Test plan

- [x] ユニットテスト追加（22個の新規テスト）
  - 各種エンコーディングの変換テスト
  - 相対URL解決のテスト
  - `parseOgpFromHtml`での相対URL処理テスト
- [x] `npm test` - 586テスト全て成功
- [x] `npm run build` - ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Japanese and international character encoding detection to improve content parsing accuracy
  * Implemented automatic URL resolution for Open Graph metadata
  * Added optimized handling for popular platforms (YouTube, X, and image proxies)

* **Dependencies**
  * Added encoding-japanese library for enhanced character set support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->