### PR TITLE
新機能: JWT Inspector ツール追加 (#228)

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -144,6 +144,7 @@ import { Route as LineEndingRouteImport } from './routes/line-ending'
 import { Route as LifeGameRouteImport } from './routes/life-game'
 import { Route as KeycodeRouteImport } from './routes/keycode'
 import { Route as KanaConvertRouteImport } from './routes/kana-convert'
+import { Route as JwtInspectorRouteImport } from './routes/jwt-inspector'
 import { Route as JwtGeneratorRouteImport } from './routes/jwt-generator'
 import { Route as JwtRouteImport } from './routes/jwt'
 import { Route as JsonToZodRouteImport } from './routes/json-to-zod'
@@ -987,6 +988,11 @@ const KeycodeRoute = KeycodeRouteImport.update({
 const KanaConvertRoute = KanaConvertRouteImport.update({
   id: '/kana-convert',
   path: '/kana-convert',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JwtInspectorRoute = JwtInspectorRouteImport.update({
+  id: '/jwt-inspector',
+  path: '/jwt-inspector',
   getParentRoute: () => rootRouteImport,
 } as any)
 const JwtGeneratorRoute = JwtGeneratorRouteImport.update({
@@ -2001,6 +2007,7 @@ export interface FileRoutesByFullPath {
   '/json-to-zod': typeof JsonToZodRoute
   '/jwt': typeof JwtRoute
   '/jwt-generator': typeof JwtGeneratorRoute
+  '/jwt-inspector': typeof JwtInspectorRoute
   '/kana-convert': typeof KanaConvertRoute
   '/keycode': typeof KeycodeRoute
   '/life-game': typeof LifeGameRoute
@@ -2307,6 +2314,7 @@ export interface FileRoutesByTo {
   '/json-to-zod': typeof JsonToZodRoute
   '/jwt': typeof JwtRoute
   '/jwt-generator': typeof JwtGeneratorRoute
+  '/jwt-inspector': typeof JwtInspectorRoute
   '/kana-convert': typeof KanaConvertRoute
   '/keycode': typeof KeycodeRoute
   '/life-game': typeof LifeGameRoute
@@ -2614,6 +2622,7 @@ export interface FileRoutesById {
   '/json-to-zod': typeof JsonToZodRoute
   '/jwt': typeof JwtRoute
   '/jwt-generator': typeof JwtGeneratorRoute
+  '/jwt-inspector': typeof JwtInspectorRoute
   '/kana-convert': typeof KanaConvertRoute
   '/keycode': typeof KeycodeRoute
   '/life-game': typeof LifeGameRoute
@@ -2922,6 +2931,7 @@ export interface FileRouteTypes {
     | '/json-to-zod'
     | '/jwt'
     | '/jwt-generator'
+    | '/jwt-inspector'
     | '/kana-convert'
     | '/keycode'
     | '/life-game'
@@ -3228,6 +3238,7 @@ export interface FileRouteTypes {
     | '/json-to-zod'
     | '/jwt'
     | '/jwt-generator'
+    | '/jwt-inspector'
     | '/kana-convert'
     | '/keycode'
     | '/life-game'
@@ -3534,6 +3545,7 @@ export interface FileRouteTypes {
     | '/json-to-zod'
     | '/jwt'
     | '/jwt-generator'
+    | '/jwt-inspector'
     | '/kana-convert'
     | '/keycode'
     | '/life-game'
@@ -3841,6 +3853,7 @@ export interface RootRouteChildren {
   JsonToZodRoute: typeof JsonToZodRoute
   JwtRoute: typeof JwtRoute
   JwtGeneratorRoute: typeof JwtGeneratorRoute
+  JwtInspectorRoute: typeof JwtInspectorRoute
   KanaConvertRoute: typeof KanaConvertRoute
   KeycodeRoute: typeof KeycodeRoute
   LifeGameRoute: typeof LifeGameRoute
@@ -4927,6 +4940,13 @@ declare module '@tanstack/react-router' {
       path: '/kana-convert'
       fullPath: '/kana-convert'
       preLoaderRoute: typeof KanaConvertRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jwt-inspector': {
+      id: '/jwt-inspector'
+      path: '/jwt-inspector'
+      fullPath: '/jwt-inspector'
+      preLoaderRoute: typeof JwtInspectorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jwt-generator': {
@@ -6281,6 +6301,7 @@ const rootRouteChildren: RootRouteChildren = {
   JsonToZodRoute: JsonToZodRoute,
   JwtRoute: JwtRoute,
   JwtGeneratorRoute: JwtGeneratorRoute,
+  JwtInspectorRoute: JwtInspectorRoute,
   KanaConvertRoute: KanaConvertRoute,
   KeycodeRoute: KeycodeRoute,
   LifeGameRoute: LifeGameRoute,

--- a/app/routes/jwt-inspector.tsx
+++ b/app/routes/jwt-inspector.tsx
@@ -1,0 +1,425 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SITE_BASE_URL, SITE_OGP_IMAGE } from "../constants/site";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import {
+  decodeJWT,
+  analyzeClaims,
+  verifyJwt,
+  type DecodedJWT,
+  type JwtClaimAnalysis,
+  type ClaimStatus,
+  type JwtVerifyResult,
+} from "../utils/jwt";
+import { Button } from "~/components/ui/button";
+import { Textarea } from "~/components/ui/textarea";
+import { TipsCard } from "~/components/TipsCard";
+import { ErrorMessage } from "~/components/ErrorMessage";
+import { StatusAnnouncer } from "~/hooks/useStatusAnnouncement";
+import { useCopyWithFeedback } from "~/hooks/useCopyWithFeedback";
+import { useKeyboardShortcut } from "~/hooks/useKeyboardShortcut";
+
+export const Route = createFileRoute("/jwt-inspector")({
+  head: () => ({
+    meta: [
+      { title: "JWT Inspector | Web ツール集" },
+      {
+        name: "description",
+        content:
+          "JWTのヘッダー・ペイロードをデコードし、HS256/384/512・RS256/384/512・ES256/384の署名検証と有効期限解析をブラウザ内で実行。",
+      },
+      { property: "og:title", content: "JWT Inspector | Web ツール集" },
+      {
+        property: "og:description",
+        content:
+          "JWTのヘッダー・ペイロードをデコードし、HS256/384/512・RS256/384/512・ES256/384の署名検証と有効期限解析をブラウザ内で実行。",
+      },
+      { property: "og:url", content: `${SITE_BASE_URL}/jwt-inspector` },
+      { property: "og:type", content: "website" },
+      { property: "og:image", content: SITE_OGP_IMAGE },
+      { name: "twitter:title", content: "JWT Inspector | Web ツール集" },
+      {
+        name: "twitter:description",
+        content:
+          "JWTのヘッダー・ペイロードをデコードし、署名検証と有効期限解析をブラウザ内で実行。",
+      },
+    ],
+  }),
+  component: JwtInspector,
+});
+
+/** 秒を人間向けの短い表記に整形する（1d 2h 3m 4s） */
+function formatDuration(totalSeconds: number): string {
+  const sign = totalSeconds < 0 ? "-" : "";
+  const s = Math.abs(Math.floor(totalSeconds));
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (!days && !hours) parts.push(`${seconds}s`);
+  return sign + (parts.join(" ") || "0s");
+}
+
+/** クレーム1行の表示用データ */
+function ClaimRow({
+  label,
+  status,
+  mode,
+}: {
+  label: string;
+  status: ClaimStatus;
+  mode: "exp" | "iat" | "nbf";
+}) {
+  if (!status.present) {
+    return (
+      <div className="jwti-claim-row jwti-claim-absent">
+        <span className="jwti-claim-label">{label}</span>
+        <span className="jwti-claim-value">未設定</span>
+      </div>
+    );
+  }
+
+  const invalidClass = status.invalid ? " jwti-claim-invalid" : " jwti-claim-valid";
+  const relative =
+    status.deltaSeconds === undefined
+      ? ""
+      : mode === "exp"
+        ? status.invalid
+          ? `${formatDuration(-status.deltaSeconds)} 前に失効`
+          : `残り ${formatDuration(status.deltaSeconds)}`
+        : mode === "nbf"
+          ? status.invalid
+            ? `${formatDuration(status.deltaSeconds)} 後に発効`
+            : `${formatDuration(-status.deltaSeconds)} 前に発効`
+          : `${formatDuration(status.deltaSeconds)} 前に発行`;
+
+  return (
+    <div className={`jwti-claim-row${invalidClass}`}>
+      <span className="jwti-claim-label">{label}</span>
+      <span className="jwti-claim-value">
+        <code>{status.value}</code>
+        <span className="jwti-claim-date">{status.dateString}</span>
+        <span className="jwti-claim-relative">{relative}</span>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * JWT Inspector: デコード + 時刻クレーム解析 + 署名検証を1画面で提供する。
+ * 秘密情報はローカル処理のみで外部送信しない。
+ */
+function JwtInspector() {
+  const [inputToken, setInputToken] = useState("");
+  const [key, setKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [decoded, setDecoded] = useState<DecodedJWT | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [verifyResult, setVerifyResult] = useState<JwtVerifyResult | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const { statusRef, announceStatus, copyWithFeedback } = useCopyWithFeedback();
+
+  // 1秒ごとに現在時刻を更新（有効期限のリアルタイム表示用、デコード済みのときだけ）
+  useEffect(() => {
+    if (!decoded) return;
+    const id = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [decoded]);
+
+  // 鍵を変更したら過去の検証結果は無効化する
+  useEffect(() => {
+    setVerifyResult(null);
+  }, [key]);
+
+  // 入力が変わったら自動デコード
+  useEffect(() => {
+    const trimmed = inputToken.trim();
+    if (!trimmed) {
+      setDecoded(null);
+      setErrorMessage("");
+      setVerifyResult(null);
+      return;
+    }
+    try {
+      const result = decodeJWT(trimmed);
+      setDecoded(result);
+      setErrorMessage("");
+      setVerifyResult(null);
+    } catch (error) {
+      setDecoded(null);
+      setVerifyResult(null);
+      setErrorMessage(error instanceof Error ? error.message : "デコードに失敗しました");
+    }
+  }, [inputToken]);
+
+  const analysis: JwtClaimAnalysis | null = useMemo(() => {
+    if (!decoded) return null;
+    return analyzeClaims(decoded.payloadRaw, now);
+  }, [decoded, now]);
+
+  const headerAlg = useMemo<string>(() => {
+    if (!decoded) return "";
+    try {
+      const parsed = JSON.parse(decoded.headerRaw) as { alg?: unknown };
+      return typeof parsed.alg === "string" ? parsed.alg : "";
+    } catch {
+      return "";
+    }
+  }, [decoded]);
+
+  const handleVerify = useCallback(async () => {
+    if (!decoded) return;
+    if (!key.trim()) {
+      setVerifyResult({
+        verified: false,
+        algorithm: headerAlg || "unknown",
+        error: "検証用のシークレット/公開鍵を入力してください",
+      });
+      announceStatus("エラー: 検証用のシークレット/公開鍵を入力してください");
+      return;
+    }
+    setVerifying(true);
+    try {
+      const result = await verifyJwt(inputToken, key);
+      setVerifyResult(result);
+      announceStatus(result.verified ? "署名検証に成功しました" : "署名検証に失敗しました");
+    } finally {
+      setVerifying(false);
+    }
+  }, [decoded, inputToken, key, headerAlg, announceStatus]);
+
+  const handleClear = useCallback(() => {
+    setInputToken("");
+    setKey("");
+    setDecoded(null);
+    setErrorMessage("");
+    setVerifyResult(null);
+    announceStatus("入力と出力をクリアしました");
+    inputRef.current?.focus();
+  }, [announceStatus]);
+
+  useKeyboardShortcut("Enter", handleVerify, { ctrl: true });
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <>
+      <div className="tool-container">
+        <form onSubmit={(e) => e.preventDefault()} aria-label="JWT Inspector フォーム">
+          <div className="converter-section">
+            <label htmlFor="jwti-input" className="section-title">
+              JWT トークン
+            </label>
+            <Textarea
+              id="jwti-input"
+              ref={inputRef}
+              value={inputToken}
+              onChange={(e) => setInputToken(e.target.value)}
+              placeholder="eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMiJ9.xxx"
+              aria-label="JWTトークン入力欄"
+              className="jwt-monospace-output"
+            />
+          </div>
+
+          <ErrorMessage message={errorMessage} />
+
+          {decoded && (
+            <>
+              <div className="jwti-meta">
+                <span className="jwti-meta-chip">
+                  alg: <strong>{headerAlg || "unknown"}</strong>
+                </span>
+              </div>
+
+              {/* クレーム解析 */}
+              {analysis && (
+                <div className="converter-section">
+                  <div className="section-title">クレーム解析</div>
+                  <div className="jwti-claims">
+                    <ClaimRow label="iat (発行時刻)" status={analysis.iat} mode="iat" />
+                    <ClaimRow label="nbf (有効開始)" status={analysis.nbf} mode="nbf" />
+                    <ClaimRow label="exp (有効期限)" status={analysis.exp} mode="exp" />
+                  </div>
+                </div>
+              )}
+
+              {/* ヘッダー */}
+              <div className="jwt-output-section">
+                <div className="jwt-output-header">
+                  <label htmlFor="jwti-header" className="section-title">
+                    ヘッダー (Header)
+                  </label>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="jwt-copy-button btn-secondary"
+                    onClick={() => copyWithFeedback(decoded.header, "ヘッダーをコピーしました")}
+                    aria-label="ヘッダーをコピー"
+                  >
+                    コピー
+                  </Button>
+                </div>
+                <Textarea
+                  id="jwti-header"
+                  value={decoded.header}
+                  readOnly
+                  aria-label="デコードされたヘッダー"
+                  className="jwt-monospace-output"
+                />
+              </div>
+
+              {/* ペイロード */}
+              <div className="jwt-output-section">
+                <div className="jwt-output-header">
+                  <label htmlFor="jwti-payload" className="section-title">
+                    ペイロード (Payload)
+                  </label>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="jwt-copy-button btn-secondary"
+                    onClick={() => copyWithFeedback(decoded.payload, "ペイロードをコピーしました")}
+                    aria-label="ペイロードをコピー"
+                  >
+                    コピー
+                  </Button>
+                </div>
+                <Textarea
+                  id="jwti-payload"
+                  value={decoded.payload}
+                  readOnly
+                  aria-label="デコードされたペイロード"
+                  className="jwt-monospace-output"
+                />
+              </div>
+
+              {/* 署名検証: HS はシングル行、RS / ES は複数行（PEM または JWK） */}
+              {headerAlg && (headerAlg.startsWith("RS") || headerAlg.startsWith("ES")) ? (
+                <div className="converter-section">
+                  <label htmlFor="jwti-pem" className="section-title">
+                    公開鍵（PEM または JWK JSON）
+                  </label>
+                  <Textarea
+                    id="jwti-pem"
+                    value={key}
+                    onChange={(e) => setKey(e.target.value)}
+                    placeholder={
+                      "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"
+                    }
+                    aria-label="PEM または JWK 公開鍵入力欄"
+                    className="jwt-monospace-output"
+                  />
+                </div>
+              ) : (
+                <div className="converter-section">
+                  <label htmlFor="jwti-key" className="section-title">
+                    シークレット
+                  </label>
+                  <div className="jwt-gen-secret-wrapper">
+                    <input
+                      id="jwti-key"
+                      type={showKey ? "text" : "password"}
+                      value={key}
+                      onChange={(e) => setKey(e.target.value)}
+                      placeholder="HMAC 共通鍵（シークレット文字列）"
+                      aria-label="HMAC 検証用シークレット"
+                      className="jwt-gen-secret-input"
+                      autoComplete="off"
+                    />
+                    <button
+                      type="button"
+                      className="jwt-gen-secret-toggle"
+                      onClick={() => setShowKey((v) => !v)}
+                      aria-pressed={showKey}
+                      aria-label={showKey ? "シークレットを非表示" : "シークレットを表示"}
+                    >
+                      {showKey ? "非表示" : "表示"}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              <div className="button-group" role="group" aria-label="検証操作">
+                <Button
+                  type="button"
+                  className="btn-primary"
+                  onClick={handleVerify}
+                  disabled={verifying}
+                  aria-label="署名を検証"
+                >
+                  {verifying ? "検証中..." : "署名を検証"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="btn-clear"
+                  onClick={handleClear}
+                  aria-label="入力と出力をクリア"
+                >
+                  クリア
+                </Button>
+              </div>
+
+              {verifyResult && (
+                <div
+                  className={`jwti-verify-result ${verifyResult.verified ? "ok" : "ng"}`}
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span className="jwti-verify-badge">
+                    {verifyResult.verified ? "✓ 署名検証成功" : "✗ 署名検証失敗"}
+                  </span>
+                  <span className="jwti-verify-detail">
+                    alg: {verifyResult.algorithm}
+                    {verifyResult.error ? ` — ${verifyResult.error}` : ""}
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+        </form>
+
+        <TipsCard
+          sections={[
+            {
+              title: "使い方",
+              items: [
+                "JWT トークンを入力すると自動でデコードされます",
+                "exp / iat / nbf クレームは有効/失効を色分け表示し、残り時間を秒単位で更新します",
+                "HS256/384/512 はシークレット文字列を入力し「署名を検証」をクリック",
+                "RS256/384/512・ES256/384 は PEM 公開鍵または JWK（JSON 文字列）を入力",
+                "キーボードショートカット: Ctrl+Enter で検証実行",
+              ],
+            },
+            {
+              title: "セキュリティ",
+              items: [
+                "入力内容はブラウザ内で完結し、サーバーへ送信されません",
+                "署名検証は Web Crypto API（crypto.subtle.verify）を使用します",
+                "alg=none のトークンはセキュリティ上の理由から常に失敗扱いになります",
+              ],
+            },
+            {
+              title: "対応アルゴリズム",
+              items: [
+                "HS256 / HS384 / HS512（HMAC + SHA）",
+                "RS256 / RS384 / RS512（RSASSA-PKCS1-v1_5）",
+                "ES256 / ES384（ECDSA P-256 / P-384）",
+              ],
+            },
+          ]}
+        />
+      </div>
+
+      <StatusAnnouncer statusRef={statusRef} />
+    </>
+  );
+}

--- a/app/routes/release-notes.tsx
+++ b/app/routes/release-notes.tsx
@@ -43,6 +43,12 @@ export const releases: Release[] = [
     date: "2026-04-18",
     entries: [
       {
+        type: "feat",
+        title: "新ツール追加: JWT Inspector",
+        description:
+          "JWTのヘッダー・ペイロードをデコードし、exp/iat/nbfをリアルタイムで評価。HS256/384/512・RS256/384/512・ES256/384の署名検証をWeb Crypto APIでブラウザ内完結（秘密情報はサーバー送信なし）。",
+      },
+      {
         type: "fix",
         title: "和暦変換: 元号期間の終了日が年のみで表示されていた不具合を修正",
         description:

--- a/app/routes/top.tsx
+++ b/app/routes/top.tsx
@@ -1477,6 +1477,13 @@ export const toolCatalog: ToolCategory[] = [
         icon: "🔓",
       },
       {
+        path: "/jwt-inspector",
+        label: "JWT Inspector",
+        description:
+          "JWTのヘッダー・ペイロード解析に加え、HS/RS/ES の署名検証と exp/iat/nbf の有効期限判定をブラウザ内で実行。",
+        icon: "🔍",
+      },
+      {
         path: "/totp",
         label: "TOTP生成",
         description:

--- a/app/styles.css
+++ b/app/styles.css
@@ -71,6 +71,7 @@
 @import "./styles/tools/slug.css";
 @import "./styles/tools/mermaid.css";
 @import "./styles/tools/jwt-generator.css";
+@import "./styles/tools/jwt-inspector.css";
 @import "./styles/tools/totp.css";
 @import "./styles/tools/color-palette.css";
 

--- a/app/styles/tools/jwt-inspector.css
+++ b/app/styles/tools/jwt-inspector.css
@@ -1,0 +1,127 @@
+/* JWT Inspector ツール */
+
+.jwti-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.jwti-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-family: "JetBrains Mono", "Space Mono", monospace;
+  background: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-on-surface-variant);
+  border-radius: 999px;
+}
+
+.jwti-claims {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
+.jwti-claim-row {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  align-items: baseline;
+  padding: 0.55rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-variant);
+  gap: 0.75rem;
+}
+
+.jwti-claim-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.jwti-claim-value {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-family: "JetBrains Mono", "Space Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--md-sys-color-on-surface);
+  word-break: break-all;
+}
+
+.jwti-claim-date {
+  font-size: 0.72rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.jwti-claim-relative {
+  font-size: 0.72rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.jwti-claim-absent {
+  opacity: 0.6;
+}
+
+.jwti-claim-valid {
+  border-color: rgba(34, 197, 94, 0.6);
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.jwti-claim-invalid {
+  border-color: rgba(239, 68, 68, 0.6);
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.jwti-hint {
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.jwti-verify-result {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid transparent;
+}
+
+.jwti-verify-result.ok {
+  background: rgba(34, 197, 94, 0.08);
+  border-color: rgba(34, 197, 94, 0.55);
+  color: var(--md-sys-color-on-surface);
+}
+
+.jwti-verify-result.ng {
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.55);
+  color: var(--md-sys-color-on-surface);
+}
+
+.jwti-verify-badge {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.jwti-verify-detail {
+  font-family: "JetBrains Mono", "Space Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--md-sys-color-on-surface-variant);
+  word-break: break-all;
+}
+
+@media (max-width: 480px) {
+  .jwti-claim-row {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+}

--- a/app/utils/jwt.ts
+++ b/app/utils/jwt.ts
@@ -114,8 +114,20 @@ export function decodeJWT(token: string): DecodedJWT {
 
 // ===== JWT生成ユーティリティ =====
 
-/** JWT署名アルゴリズム */
+/** JWT署名アルゴリズム（HMAC） */
 export type JwtAlgorithm = "HS256" | "HS384" | "HS512";
+
+/** JWT検証で対応する署名アルゴリズム */
+export type JwtVerifyAlgorithm =
+  | "HS256"
+  | "HS384"
+  | "HS512"
+  | "RS256"
+  | "RS384"
+  | "RS512"
+  | "ES256"
+  | "ES384"
+  | "none";
 
 /** JWT生成の入力パラメータ */
 export interface JwtGeneratorInput {
@@ -217,4 +229,257 @@ export async function generateJWT(input: JwtGeneratorInput): Promise<JwtGenerato
     header: JSON.stringify(headerObj, null, 2),
     payload: JSON.stringify(finalPayload, null, 2),
   };
+}
+
+// ===== JWT Inspector（検証・解析）ユーティリティ =====
+
+/** exp/iat/nbf クレームの評価結果 */
+export interface ClaimStatus {
+  /** クレームが存在するか */
+  present: boolean;
+  /** Unix秒 */
+  value?: number;
+  /** ISO8601 の日時表示（ローカルタイム） */
+  dateString?: string;
+  /** exp で期限切れ、nbf でまだ有効でない */
+  invalid?: boolean;
+  /** 現在時刻との差（秒）。exp は残り、iat は経過、nbf は発効までの秒 */
+  deltaSeconds?: number;
+}
+
+/** JWT ペイロードの時刻クレーム解析結果 */
+export interface JwtClaimAnalysis {
+  exp: ClaimStatus;
+  iat: ClaimStatus;
+  nbf: ClaimStatus;
+  /** 評価時点の Unix 秒 */
+  currentTime: number;
+}
+
+/**
+ * ペイロード JSON 文字列から exp/iat/nbf を取り出し、現在時刻基準で状態を判定する。
+ *
+ * @param payloadRaw JSON 文字列化されたペイロード
+ * @param now 現在時刻（Unix 秒、デフォルトは `Math.floor(Date.now() / 1000)`）
+ */
+export function analyzeClaims(payloadRaw: string, now?: number): JwtClaimAnalysis {
+  const currentTime = now ?? Math.floor(Date.now() / 1000);
+  const emptyStatus: ClaimStatus = { present: false };
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(payloadRaw);
+  } catch {
+    return { exp: emptyStatus, iat: emptyStatus, nbf: emptyStatus, currentTime };
+  }
+
+  const toStatus = (raw: unknown, kind: "exp" | "iat" | "nbf"): ClaimStatus => {
+    if (typeof raw !== "number" || !Number.isFinite(raw)) return emptyStatus;
+    const dateString = new Date(raw * 1000).toISOString();
+    if (kind === "exp") {
+      return {
+        present: true,
+        value: raw,
+        dateString,
+        invalid: currentTime >= raw,
+        deltaSeconds: raw - currentTime,
+      };
+    }
+    if (kind === "nbf") {
+      return {
+        present: true,
+        value: raw,
+        dateString,
+        invalid: currentTime < raw,
+        deltaSeconds: raw - currentTime,
+      };
+    }
+    // iat
+    return {
+      present: true,
+      value: raw,
+      dateString,
+      deltaSeconds: currentTime - raw,
+    };
+  };
+
+  return {
+    exp: toStatus(parsed.exp, "exp"),
+    iat: toStatus(parsed.iat, "iat"),
+    nbf: toStatus(parsed.nbf, "nbf"),
+    currentTime,
+  };
+}
+
+/** Base64URL 文字列をバイト配列へ変換する */
+export function base64UrlToBytes(str: string): Uint8Array {
+  let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (base64.length % 4 !== 0) base64 += "=";
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** PEM 形式の公開鍵文字列から SPKI バイト列を抽出する */
+export function pemToSpki(pem: string): Uint8Array {
+  const stripped = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  if (!stripped) throw new Error("PEMが空です");
+  const binary = atob(stripped);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** 検証結果 */
+export interface JwtVerifyResult {
+  /** 署名検証に成功したか */
+  verified: boolean;
+  /** 使用したアルゴリズム（ヘッダー由来。未対応・不明なら string のまま） */
+  algorithm: string;
+  /** 失敗理由（失敗時のみ） */
+  error?: string;
+}
+
+/** ハッシュ名対応表 */
+const HASH_BY_ALG: Record<string, "SHA-256" | "SHA-384" | "SHA-512"> = {
+  HS256: "SHA-256",
+  HS384: "SHA-384",
+  HS512: "SHA-512",
+  RS256: "SHA-256",
+  RS384: "SHA-384",
+  RS512: "SHA-512",
+  ES256: "SHA-256",
+  ES384: "SHA-384",
+};
+
+/**
+ * JWT の署名を検証する。
+ *
+ * - HS256/384/512: `key` を UTF-8 シークレット文字列として扱う
+ * - RS256/384/512: `key` を SPKI PEM または JWK（JSON 文字列）として扱う
+ * - ES256/384: `key` を SPKI PEM または JWK（JSON 文字列）として扱う
+ * - alg が "none" または未知の場合は `verified=false`
+ *
+ * 秘密情報は呼び出し元に留まる（Web Crypto API のみ使用）。
+ *
+ * @param token JWT トークン文字列
+ * @param key HMAC シークレットまたは公開鍵（PEM / JWK JSON）
+ * @returns 検証結果
+ */
+export async function verifyJwt(token: string, key: string): Promise<JwtVerifyResult> {
+  const parts = token.trim().split(".");
+  if (parts.length !== 3) {
+    return { verified: false, algorithm: "unknown", error: "JWTの形式が不正です" };
+  }
+  const [headerPart, payloadPart, signaturePart] = parts;
+  if (!headerPart || !payloadPart || !signaturePart) {
+    return { verified: false, algorithm: "unknown", error: "JWTの各パートが空です" };
+  }
+
+  let headerJson: { alg?: string };
+  try {
+    headerJson = JSON.parse(base64UrlDecode(headerPart));
+  } catch {
+    return { verified: false, algorithm: "unknown", error: "ヘッダーのデコードに失敗しました" };
+  }
+  const alg = headerJson.alg ?? "unknown";
+
+  if (alg === "none") {
+    return {
+      verified: false,
+      algorithm: alg,
+      error: "alg=none は検証不可（セキュリティ上も推奨されません）",
+    };
+  }
+
+  const hash = HASH_BY_ALG[alg];
+  if (!hash) {
+    return { verified: false, algorithm: alg, error: `未対応のアルゴリズム: ${alg}` };
+  }
+
+  const signingInput = new TextEncoder().encode(`${headerPart}.${payloadPart}`);
+  const signatureBytes = base64UrlToBytes(signaturePart);
+
+  try {
+    if (alg.startsWith("HS")) {
+      const cryptoKey = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(key),
+        { name: "HMAC", hash: { name: hash } },
+        false,
+        ["verify"],
+      );
+      const verified = await crypto.subtle.verify(
+        "HMAC",
+        cryptoKey,
+        signatureBytes.buffer as ArrayBuffer,
+        signingInput.buffer as ArrayBuffer,
+      );
+      return { verified, algorithm: alg };
+    }
+
+    // 公開鍵アルゴリズム: PEM もしくは JWK（JSON）を受け付ける
+    const trimmedKey = key.trim();
+    const isJwk = trimmedKey.startsWith("{");
+
+    if (alg.startsWith("RS")) {
+      const cryptoKey = isJwk
+        ? await crypto.subtle.importKey(
+            "jwk",
+            JSON.parse(trimmedKey),
+            { name: "RSASSA-PKCS1-v1_5", hash: { name: hash } },
+            false,
+            ["verify"],
+          )
+        : await crypto.subtle.importKey(
+            "spki",
+            pemToSpki(trimmedKey).buffer as ArrayBuffer,
+            { name: "RSASSA-PKCS1-v1_5", hash: { name: hash } },
+            false,
+            ["verify"],
+          );
+      const verified = await crypto.subtle.verify(
+        "RSASSA-PKCS1-v1_5",
+        cryptoKey,
+        signatureBytes.buffer as ArrayBuffer,
+        signingInput.buffer as ArrayBuffer,
+      );
+      return { verified, algorithm: alg };
+    }
+
+    if (alg.startsWith("ES")) {
+      const namedCurve = alg === "ES256" ? "P-256" : "P-384";
+      const cryptoKey = isJwk
+        ? await crypto.subtle.importKey(
+            "jwk",
+            JSON.parse(trimmedKey),
+            { name: "ECDSA", namedCurve },
+            false,
+            ["verify"],
+          )
+        : await crypto.subtle.importKey(
+            "spki",
+            pemToSpki(trimmedKey).buffer as ArrayBuffer,
+            { name: "ECDSA", namedCurve },
+            false,
+            ["verify"],
+          );
+      const verified = await crypto.subtle.verify(
+        { name: "ECDSA", hash: { name: hash } },
+        cryptoKey,
+        signatureBytes.buffer as ArrayBuffer,
+        signingInput.buffer as ArrayBuffer,
+      );
+      return { verified, algorithm: alg };
+    }
+
+    return { verified: false, algorithm: alg, error: `未対応のアルゴリズム: ${alg}` };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "検証中にエラーが発生しました";
+    return { verified: false, algorithm: alg, error: message };
+  }
 }

--- a/tests/unit/jwt-inspector.test.ts
+++ b/tests/unit/jwt-inspector.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  analyzeClaims,
+  base64UrlToBytes,
+  generateJWT,
+  pemToSpki,
+  verifyJwt,
+} from "../../app/utils/jwt";
+
+describe("analyzeClaims", () => {
+  const now = 1700000000;
+
+  it("exp/iat/nbf すべて未設定のとき present=false を返す", () => {
+    const result = analyzeClaims("{}", now);
+    expect(result.exp.present).toBe(false);
+    expect(result.iat.present).toBe(false);
+    expect(result.nbf.present).toBe(false);
+    expect(result.currentTime).toBe(now);
+  });
+
+  it("exp が現在時刻より未来なら invalid=false、残り秒を返す", () => {
+    const result = analyzeClaims(JSON.stringify({ exp: now + 60 }), now);
+    expect(result.exp.present).toBe(true);
+    expect(result.exp.invalid).toBe(false);
+    expect(result.exp.deltaSeconds).toBe(60);
+  });
+
+  it("exp が現在時刻以前なら invalid=true を返す", () => {
+    const result = analyzeClaims(JSON.stringify({ exp: now - 1 }), now);
+    expect(result.exp.invalid).toBe(true);
+    expect(result.exp.deltaSeconds).toBe(-1);
+  });
+
+  it("exp が現在時刻と等しい場合は invalid=true（RFC 7519 §4.1.4: current time MUST be before exp）", () => {
+    const result = analyzeClaims(JSON.stringify({ exp: now }), now);
+    expect(result.exp.invalid).toBe(true);
+    expect(result.exp.deltaSeconds).toBe(0);
+  });
+
+  it("nbf が現在時刻より未来なら invalid=true（まだ発効していない）", () => {
+    const result = analyzeClaims(JSON.stringify({ nbf: now + 30 }), now);
+    expect(result.nbf.invalid).toBe(true);
+    expect(result.nbf.deltaSeconds).toBe(30);
+  });
+
+  it("iat は経過時間（秒）を deltaSeconds に入れる", () => {
+    const result = analyzeClaims(JSON.stringify({ iat: now - 120 }), now);
+    expect(result.iat.present).toBe(true);
+    expect(result.iat.deltaSeconds).toBe(120);
+    expect(result.iat.invalid).toBeUndefined();
+  });
+
+  it("非数値の exp は無視する", () => {
+    const result = analyzeClaims(JSON.stringify({ exp: "not-a-number" }), now);
+    expect(result.exp.present).toBe(false);
+  });
+
+  it("不正なJSONは全クレーム未設定として返す", () => {
+    const result = analyzeClaims("{invalid json", now);
+    expect(result.exp.present).toBe(false);
+    expect(result.iat.present).toBe(false);
+    expect(result.nbf.present).toBe(false);
+  });
+});
+
+describe("base64UrlToBytes", () => {
+  it("Base64URL 文字列をバイト列へ変換する", () => {
+    const bytes = base64UrlToBytes("SGVsbG8");
+    expect(Array.from(bytes)).toEqual([72, 101, 108, 108, 111]);
+  });
+
+  it("URL安全文字（- _）を正しく扱う", () => {
+    // "+/" を URL-safe にすると "-_" に対応する
+    const bytes = base64UrlToBytes("-_8");
+    expect(Array.from(bytes)).toEqual([0xfb, 0xff]);
+  });
+});
+
+describe("pemToSpki", () => {
+  it("BEGIN/END と改行を除去して Base64 デコードする", () => {
+    // "hello" を Base64 エンコードした文字列
+    const pem = "-----BEGIN PUBLIC KEY-----\naGVsbG8=\n-----END PUBLIC KEY-----";
+    const bytes = pemToSpki(pem);
+    expect(new TextDecoder().decode(bytes)).toBe("hello");
+  });
+
+  it("空の PEM はエラー", () => {
+    expect(() => pemToSpki("-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----")).toThrow();
+  });
+});
+
+describe("verifyJwt (HS256/384/512)", () => {
+  it("正しいシークレットで HS256 署名を検証できる", async () => {
+    const generated = await generateJWT({
+      payload: '{"sub":"42"}',
+      secret: "correct-secret",
+      algorithm: "HS256",
+    });
+    const result = await verifyJwt(generated.token, "correct-secret");
+    expect(result.verified).toBe(true);
+    expect(result.algorithm).toBe("HS256");
+  });
+
+  it("誤ったシークレットでは検証失敗", async () => {
+    const generated = await generateJWT({
+      payload: '{"sub":"42"}',
+      secret: "correct-secret",
+      algorithm: "HS256",
+    });
+    const result = await verifyJwt(generated.token, "wrong-secret");
+    expect(result.verified).toBe(false);
+    expect(result.algorithm).toBe("HS256");
+  });
+
+  it("HS384 の署名を検証できる", async () => {
+    const generated = await generateJWT({
+      payload: '{"x":1}',
+      secret: "sec384",
+      algorithm: "HS384",
+    });
+    const result = await verifyJwt(generated.token, "sec384");
+    expect(result.verified).toBe(true);
+    expect(result.algorithm).toBe("HS384");
+  });
+
+  it("HS512 の署名を検証できる", async () => {
+    const generated = await generateJWT({
+      payload: '{"x":1}',
+      secret: "sec512",
+      algorithm: "HS512",
+    });
+    const result = await verifyJwt(generated.token, "sec512");
+    expect(result.verified).toBe(true);
+    expect(result.algorithm).toBe("HS512");
+  });
+
+  it("改竄されたペイロードは検証失敗", async () => {
+    const generated = await generateJWT({
+      payload: '{"sub":"42"}',
+      secret: "secret",
+      algorithm: "HS256",
+    });
+    const [h, , s] = generated.token.split(".");
+    // ペイロード部を別の値に差し替え
+    const tampered = `${h}.eyJzdWIiOiI5OSJ9.${s}`;
+    const result = await verifyJwt(tampered, "secret");
+    expect(result.verified).toBe(false);
+  });
+
+  it("3セグメントでないトークンはエラー", async () => {
+    const result = await verifyJwt("abc.def", "secret");
+    expect(result.verified).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("alg=none は常に verified=false", async () => {
+    // { "alg": "none" } ヘッダーを作成
+    const header = btoa('{"alg":"none","typ":"JWT"}')
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const payload = btoa('{"sub":"42"}').replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const token = `${header}.${payload}.sig`;
+    const result = await verifyJwt(token, "");
+    expect(result.verified).toBe(false);
+    expect(result.algorithm).toBe("none");
+  });
+
+  it("未対応アルゴリズムは verified=false + エラー", async () => {
+    const header = btoa('{"alg":"PS256"}')
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const payload = btoa('{"sub":"x"}').replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const token = `${header}.${payload}.sig`;
+    const result = await verifyJwt(token, "any");
+    expect(result.verified).toBe(false);
+    expect(result.error).toMatch(/未対応/);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #228 の JWT Inspector を実装したお。HS/RS/ES の署名検証と有効期限のリアルタイム解析をブラウザ内完結で行う新ツール。

## 主な変更

- `app/utils/jwt.ts` に検証ユーティリティを追加:
  - `analyzeClaims` — exp/iat/nbf を現在時刻基準で評価（RFC 7519 §4.1.4 準拠、`current time >= exp` は invalid）
  - `verifyJwt` — HS256/384/512、RS256/384/512、ES256/384 を Web Crypto API で検証
  - `base64UrlToBytes` / `pemToSpki` — 署名バイト列・PEM 公開鍵のパース
- `app/routes/jwt-inspector.tsx` — 自動デコード・1秒更新の期限タイマー・alg 応じて入力 UI を切替
- `app/styles/tools/jwt-inspector.css` — 有効/失効のカラーコーディング
- `app/routes/top.tsx` / `app/styles.css` に登録
- `app/routes/release-notes.tsx` に feat エントリ追加 (2026-04-18)
- `tests/unit/jwt-inspector.test.ts` — 20 件のユニットテスト

## セキュリティ方針

- 秘密情報はサーバー送信せず、`crypto.subtle.verify` でローカル検証
- `alg=none` は常に verified=false
- RS→HS アルゴリズム置換攻撃は `importKey` 段階で失敗するため安全

## 検証

- [x] `vp check` 通過（0 エラー・0 警告）
- [x] `vp test run`: 10030/10030 passing
- [x] `vp build` 成功
- [x] code-reviewer エージェントのレビュー指摘（鍵変更時の検証結果クリア、exp=now の境界テスト、タイマーのゲート）を反映

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JWT Inspector tool enabling users to decode JWT headers and payloads, evaluate claim expiration and timing (exp, iat, nbf), and verify token signatures across multiple algorithms (HS*, RS*, ES*) using in-browser Web Crypto API without transmitting secrets to external servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->